### PR TITLE
Avoid error if template include another input

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -548,7 +548,7 @@
             }, this));
 
             // Bind the change event on the dropdown elements.
-            $('li:not(.multiselect-group) input', this.$ul).on('change', $.proxy(function(event) {
+            $('li:not(.multiselect-group) input:checkbox', this.$ul).on('change', $.proxy(function(event) {
                 var $target = $(event.target);
 
                 var checked = $target.prop('checked') || false;


### PR DESCRIPTION
if template for li include an input e.g. input[type='text'], code crashes when the input was being modified
e.g. templates: 

```
{
  li: '<li><a><label></label></a><input type="text" class="volume-box form-control"/></li>'
}
```

The edit proposed bind change event on input of type checkbox only
